### PR TITLE
fix(ci): pass dispatch payload through env in update-repo

### DIFF
--- a/.github/workflows/update-repo.yml
+++ b/.github/workflows/update-repo.yml
@@ -38,19 +38,43 @@ jobs:
 
       - name: Set variables
         id: vars
+        env:
+          # On repository_dispatch every client_payload field is supplied by the
+          # caller, so interpolating these into the run body let them expand into
+          # executable shell before bash parsed the script. workflow_dispatch inputs
+          # are free text too. All of them come in as env and are read as quoted
+          # shell variables, which keeps them inert data.
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ github.event.action }}
+          PAYLOAD_VERSION: ${{ github.event.client_payload.version }}
+          PAYLOAD_TAG: ${{ github.event.client_payload.tag }}
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_TAG: ${{ inputs.tag }}
+          INPUT_PACKAGE: ${{ inputs.package }}
         run: |
-          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
-            echo "version=${{ github.event.client_payload.version }}" >> "$GITHUB_OUTPUT"
-            echo "tag=${{ github.event.client_payload.tag }}" >> "$GITHUB_OUTPUT"
-            case "${{ github.event.action }}" in
-              xcsh-release) echo "package=xcsh" >> "$GITHUB_OUTPUT" ;;
-              oh-my-xcsh-release) echo "package=oh-my-xcsh" >> "$GITHUB_OUTPUT" ;;
+          if [ "$EVENT_NAME" = "repository_dispatch" ]; then
+            version="$PAYLOAD_VERSION"
+            tag="$PAYLOAD_TAG"
+            case "$EVENT_ACTION" in
+              xcsh-release) package="xcsh" ;;
+              oh-my-xcsh-release) package="oh-my-xcsh" ;;
+              *)
+                echo "::error::unrecognised dispatch type '${EVENT_ACTION}'"
+                exit 1
+                ;;
             esac
           else
-            echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
-            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
-            echo "package=${{ inputs.package }}" >> "$GITHUB_OUTPUT"
+            version="$INPUT_VERSION"
+            tag="$INPUT_TAG"
+            package="$INPUT_PACKAGE"
           fi
+
+          # One grouped redirect rather than six (shellcheck SC2129).
+          {
+            echo "version=${version}"
+            echo "tag=${tag}"
+            echo "package=${package}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Download release assets
         env:


### PR DESCRIPTION
## Problem

The scheduled Workflow Security Audit (docs-control#775) fails on this repo with five
high-confidence template injections, all in the `Set variables` step of `update-repo.yml`:

```
error[template-injection] @ .github/workflows/update-repo.yml:43:31  client_payload.version
error[template-injection] @ .github/workflows/update-repo.yml:44:27  client_payload.tag
error[template-injection] @ .github/workflows/update-repo.yml:45:23  github.event.action
error[template-injection] @ .github/workflows/update-repo.yml:50:31  inputs.version
error[template-injection] @ .github/workflows/update-repo.yml:51:27  inputs.tag
```

**These are live vectors, not theoretical.** The workflow triggers on
`repository_dispatch`, where every `client_payload` field is caller-supplied — so
`client_payload.version` and `.tag` were expanding into the `run:` body as shell before
bash ever parsed the script. That is the same exploitable shape closed in vscode-xcsh#966.
The `workflow_dispatch` inputs are free text and were interpolated identically.

## Change

All seven expansions bound at step scope through `env:` and read as quoted shell
variables.

Two things came along with the restructure, both called out rather than smuggled in:

1. **Grouped `GITHUB_OUTPUT` writes.** `actionlint` reports a pre-existing shellcheck
   SC2129 on this step — present on `main` too (at line 41 there). Because super-linter
   lints only the files a PR changes, touching this file surfaces it and it would have
   blocked this PR. Six individual redirects became one `{ ... } >> "$GITHUB_OUTPUT"`.

2. **A guard on the `case`.** Assigning `package` in a variable rather than echoing
   directly made an existing hole visible: if `github.event.action` matched neither arm,
   no `package=` was written at all and every later step ran with an empty package name.
   The `*` arm now errors out. The `types:` filter means it should be unreachable — this
   is about failing loudly rather than silently if that ever stops being true.

If you would rather item 2 landed separately, say so and I will split it out.

## Verification

Run with zizmor **1.25.2**, the version super-linter pins.

| | exit | findings |
|---|---|---|
| before | 14 | 5 high |
| after | **0** | **none, any severity** |

`actionlint` clean across all workflows (it was failing before this change, on `main` too).

Downstream steps consume `steps.vars.outputs.{package,tag,version}` and those output names
are unchanged, so the contract to the rest of the workflow is identical. This workflow
publishes the APT repo to `gh-pages`, so the next real dispatch is worth confirming by
artifact — that the repo metadata actually regenerates — rather than by a green check.

Closes #215
