### PR TITLE
docs: verify linked-issue check

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,1 @@
+<!-- Linked-issue verification marker: #450. -->


### PR DESCRIPTION
Closes #450\n\nAdds the authorized inert documentation marker to verify the canonical linked-issue PR check.