### PR TITLE
docs: add Pages frontmatter

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,1 +1,6 @@
+---
+title: APT Repository
+description: Install F5 sales demo packages from the APT repository.
+---
+
 <!-- Linked-issue verification marker: #450. -->


### PR DESCRIPTION
Add the minimum required Starlight frontmatter to the repository documentation index while preserving its linked-issue marker. This repairs the protected-`main` Pages schema failure.

Validation:
- `bash scripts/lint-mdx-prose.sh --textlint-only docs/index.md`
- `bash scripts/check-pii.sh --scope changed --mode enforce`
- full docs build with `ghcr.io/f5-sales-demo/docs-builder@sha256:ba96cff87c091d2f39f6ec9cf94e7036fb2cad58738bb238ff22a71e6d467e92` and `--pull=never` (52 files generated)

Closes #461